### PR TITLE
Lru cache and LeelaBoard.copy optimization

### DIFF
--- a/scripts/download_match_games/download_match_games.py
+++ b/scripts/download_match_games/download_match_games.py
@@ -5,19 +5,20 @@ from lcztools.testing import WebMatchGame
 from collections import OrderedDict
 import shelve
 import sys
+import pickle
+import os
+import shutil
 
-with shelve.open('web_pgn_data.shelf') as s:
-    if 'df_matches' in s:
-        df_matches = s['df_matches'] 
-        match_dfs = s['match_dfs']
-        df_pgn = s['df_pgn']
+if os.path.exists('web_pgn.data'):
+    with open('web_pgn.data', 'rb') as f:
+        df_matches, match_dfs, df_pgn = pickle.load(f)
 
 if 'df_pgn' in dir():
-    print("Currently {} games in shelf".format(len(df_pgn)))
+    print("Currently {} games in web_pgn.data pickle".format(len(df_pgn)))
 else:
     print("No games yet in shelf...")
 # Everytime I run this, I'll grab an extra GAMES_TO_GRAB games
-GAMES_TO_GRAB = 10000
+GAMES_TO_GRAB = 100
 
 
 def get_table(url):
@@ -78,9 +79,11 @@ for match_id, row in df_matches.iterrows():
 
 print("Done... Downloaded {} files. Saving back to shelf".format(num_pgns_grabbed))
 
-with shelve.open('web_pgn_data.shelf') as s:
-    s['df_matches'] = df_matches
-    s['match_dfs'] = match_dfs
-    s['df_pgn'] = df_pgn
+if os.path.exists('web_pgn.data'):
+    shutil.copy('web_pgn.data', 'web_pgn.data.bup')
 
-print("Currently {} games in shelf".format(len(df_pgn)))
+print("Writing web_pgn.data")
+with open('web_pgn.data', 'wb') as f:
+    pickle.dump((df_matches, match_dfs, df_pgn), f)
+
+print("Currently {} games in web_pgn.data pickle".format(len(df_pgn)))

--- a/scripts/download_match_games/make_training_data.py
+++ b/scripts/download_match_games/make_training_data.py
@@ -1,0 +1,40 @@
+import shelve
+from lcztools import LeelaBoard
+import chess.pgn
+import io
+import pickle
+import sys
+
+# with shelve.open('web_pgn_data.shelf') as s:
+#     df_matches = s['df_matches']
+#     match_dfs = s['match_dfs']
+#     df_pgn = s['df_pgn']
+
+with open('web_pgn.data', 'rb') as f:
+    df_matches, match_dfs, df_pgn = pickle.load(f)
+
+
+for i, (idx, row) in enumerate(df_pgn.iterrows(), 1):
+    lcz_board = LeelaBoard()
+    pgn_game = chess.pgn.read_game(io.StringIO(row.pgn))
+    moves = [move for move in pgn_game.main_line()]
+    compressed = []
+    features = lcz_board.lcz_features()
+    compressed.append(lcz_board.compress_features(features))
+    for move in moves[:-1]:
+        # print(move)
+        lcz_board.push(move)
+        features = lcz_board.lcz_features()
+        compressed_features = lcz_board.compress_features(features)
+        compressed.append(compressed_features)
+        # assert(check_compressed_features(lcz_board, compressed_features))
+    training_game = (compressed, pgn_game.headers['Result'], row.pgn)
+    with open(f'./training_data/match_game_{idx}.data', 'wb') as f:
+        f.write(pickle.dumps(training_game))
+    print('.', end='')
+    if i%100==0:
+        print()
+    if i%1000==0:
+        print(i)
+    sys.stdout.flush()
+

--- a/src/lcztools/_leela_board.py
+++ b/src/lcztools/_leela_board.py
@@ -38,7 +38,7 @@ class LeelaBoard:
         self.is_game_over = self.pc_method('is_game_over')
         self.can_claim_draw = self.pc_method('can_claim_draw')
         self.generate_legal_moves = self.pc_method('generate_legal_moves')
-
+                
     def copy(self):
         """Note! Currently the copy constructor uses pc_board.copy(stack=False), which makes pops impossible"""
         return self.__class__(leela_board=self)
@@ -222,6 +222,19 @@ class LeelaBoard:
         boardstr = self.pc_board.__str__() + \
                 '\nTurn: {}'.format('White' if self.pc_board.turn else 'Black')
         return boardstr
+    
+    def __eq__(self, other):
+        return self.get_hash_key() == other.get_hash_key()
+    
+    def __hash__(self):
+        return hash(self.get_hash_key())
+
+    def get_hash_key(self):
+        transposition_key = self.pc_board._transposition_key() 
+        return (transposition_key +
+                (self._lcz_transposition_counter[transposition_key], self.pc_board.halfmove_clock) +
+                tuple(self.pc_board.move_stack[-8:])
+                )
 
 # lb = LeelaBoard()
 # lb.push_uci('c2c4')

--- a/src/lcztools/_leela_board.py
+++ b/src/lcztools/_leela_board.py
@@ -27,7 +27,7 @@ class LeelaBoard:
         '''If leela_board is passed as an argument, return a copy'''
         if leela_board:
             # Copy
-            self.pc_board = leela_board.pc_board.copy()
+            self.pc_board = leela_board.pc_board.copy(stack=False)
             self.lcz_stack = leela_board.lcz_stack[:]
             self._lcz_transposition_counter = leela_board._lcz_transposition_counter.copy()
         else:
@@ -40,6 +40,7 @@ class LeelaBoard:
         self.generate_legal_moves = self.pc_method('generate_legal_moves')
 
     def copy(self):
+        """Note! Currently the copy constructor uses pc_board.copy(stack=False), which makes pops impossible"""
         return self.__class__(leela_board=self)
 
     def pc_method(self, methodname):

--- a/src/lcztools/backend/_leela_net.py
+++ b/src/lcztools/backend/_leela_net.py
@@ -87,7 +87,8 @@ class LeelaNet:
         return policy_legal, value    
 
 def list_backends():
-    return ['pytorch_cpu', 'pytorch_cuda', 'pytorch_orig_cpu', 'pytorch_orig_cuda', 'tensorflow']
+    return ['pytorch_cpu', 'pytorch_cuda', 'pytorch_orig_cpu', 'pytorch_orig_cuda', 'tensorflow',
+            'pytorch_train_cpu', 'pytorch_train_cuda']
 
 def load_network(filename=None, backend=None, policy_softmax_temp=None):
     # Config will handle filename in read_weights_file
@@ -114,4 +115,11 @@ def load_network(filename=None, backend=None, policy_softmax_temp=None):
     elif backend == 'pytorch_orig_cuda':
         from lcztools.backend._leela_torch_net import LeelaLoader
         kwargs['cuda'] = True
+    elif backend == 'pytorch_train_cpu':
+        from lcztools.backend._leela_torch_net import LeelaLoader
+        kwargs['train'] = True
+    elif backend == 'pytorch_train_cuda':
+        from lcztools.backend._leela_torch_net import LeelaLoader
+        kwargs['cuda'] = True
+        kwargs['train'] = True
     return LeelaNet(LeelaLoader.from_weights_file(filename, **kwargs), policy_softmax_temp=policy_softmax_temp)

--- a/src/lcztools/backend/_leela_net.py
+++ b/src/lcztools/backend/_leela_net.py
@@ -87,7 +87,7 @@ class LeelaNet:
         return policy_legal, value    
 
 def list_backends():
-    return ['pytorch_cpu', 'pytorch_cuda', 'pytorch_orig_cpu', 'pytorch_orig_cuda', 'tensorflow',
+    return ['pytorch_eval_cpu', 'pytorch_eval_cuda', 'pytorch_cpu', 'pytorch_cuda', 'tensorflow',
             'pytorch_train_cpu', 'pytorch_train_cuda']
 
 def load_network(filename=None, backend=None, policy_softmax_temp=None):
@@ -105,14 +105,14 @@ def load_network(filename=None, backend=None, policy_softmax_temp=None):
     if backend == 'tensorflow':
         raise Exception("Tensorflow temporarily disabled, untested since latest changes")  # Temporarily
         from lcztools.backend._leela_tf_net import LeelaLoader
-    elif backend == 'pytorch_cpu':
+    elif backend == 'pytorch_eval_cpu':
         from lcztools.backend._leela_torch_eval_net import LeelaLoader
-    elif backend == 'pytorch_cuda':
+    elif backend == 'pytorch_eval_cuda':
         from lcztools.backend._leela_torch_eval_net import LeelaLoader
         kwargs['cuda'] = True
-    elif backend == 'pytorch_orig_cpu':
+    elif backend == 'pytorch_cpu':
         from lcztools.backend._leela_torch_net import LeelaLoader
-    elif backend == 'pytorch_orig_cuda':
+    elif backend == 'pytorch_cuda':
         from lcztools.backend._leela_torch_net import LeelaLoader
         kwargs['cuda'] = True
     elif backend == 'pytorch_train_cpu':

--- a/src/lcztools/backend/_leela_torch_eval_net.py
+++ b/src/lcztools/backend/_leela_torch_eval_net.py
@@ -19,11 +19,11 @@ class Normalization(nn.Module):
     def __init__(self, channels):
         super().__init__()
         self.channels = channels
-        self.mean = nn.Parameter(torch.Tensor(channels))
-        self.stddiv = nn.Parameter(torch.Tensor(channels))
+        self.mean = nn.Parameter(torch.Tensor(channels).unsqueeze(-1).unsqueeze(-1))
+        self.stddiv = nn.Parameter(torch.Tensor(channels).unsqueeze(-1).unsqueeze(-1))
 
     def forward(self, x):
-        return x.sub_(self.mean.unsqueeze(1).unsqueeze(2)).mul_(self.stddiv.unsqueeze(1).unsqueeze(2))
+        return x.sub_(self.mean).mul_(self.stddiv)
 
     def extra_repr(self):
         return 'channels={}'.format(
@@ -106,6 +106,8 @@ class LeelaModel(nn.Module):
 class LeelaLoader:
     @staticmethod
     def from_weights_file(filename, train=False, cuda=False):
+        if cuda:
+            torch.backends.cudnn.benchmark=True
         filters, blocks, weights = read_weights_file(filename)
         net = LeelaModel(filters, blocks)
         if not train:

--- a/src/lcztools/backend/_leela_torch_net.py
+++ b/src/lcztools/backend/_leela_torch_net.py
@@ -119,6 +119,8 @@ class LeelaModel(nn.Module):
 class LeelaLoader:
     @staticmethod
     def from_weights_file(filename, train=False, cuda=False):
+        if cuda:
+            torch.backends.cudnn.benchmark=True        
         filters, blocks, weights = read_weights_file(filename)
         net = LeelaModel(filters, blocks)
         if not train:

--- a/tests/lcztools.ini
+++ b/tests/lcztools.ini
@@ -9,8 +9,8 @@ weights_file = weights_run1_21754.txt.gz
 training_raw_dir = /Volumes/SeagateExternal/leela_data/training_raw/
 
 # This is the default backend to use, if none provided
-# Choices are: ['pytorch_cpu', 'pytorch_cuda', 'pytorch_orig_cpu', 'pytorch_orig_cuda', 'tensorflow']
-backend = pytorch_orig_cuda
+# Choices are: ['pytorch_eval_cpu', 'pytorch_eval_cuda', 'pytorch_cpu', 'pytorch_cuda', 'pytorch_train_cpu', 'pytorch_train_cuda', 'tensorflow']
+backend = pytorch_cuda
 
 ### This is the lczero engine to use, only currently used for testing/validation
 ## NOTE: lczero no longer supported!!!


### PR DESCRIPTION
Most important changes here are:
1. LeelaBoard.copy(), which is changed to call pc_board.copy(False) -- this greatly improves performance of the copy method (which was taking a lot of time).
2. Add hashing support to LeelaBoard for functools LRU cache to work.
3. Change default network to the original (trainable) pytorch network, which uses normal BatchNorm layers. This seems to be a little faster with cuda than the pytorch eval implementation (which adds a simplified normalization layer).

Other random changes just pulled in from master.